### PR TITLE
Protect against cases where the offset is calculated wrong

### DIFF
--- a/src/drawer.js
+++ b/src/drawer.js
@@ -100,17 +100,16 @@ export default class Drawer extends util.Observer {
             progress =
                 (clientX - bbox.left) *
                     (this.params.pixelRatio / nominalWidth) || 0;
-
-            if (progress > 1) {
-                progress = 1;
-            }
         } else {
             progress =
                 (clientX - bbox.left + this.wrapper.scrollLeft) /
                     this.wrapper.scrollWidth || 0;
         }
 
-        return progress;
+        // clientX is an integer, while bbox.left is a double, so if the user clicks on the very edge of the wave
+        // an error is thrown, since clientX - bbox.left = a negative number
+        // This will protect that our value is b/w 0-1
+        return Math.min(Math.max(0, progress), 1);
     }
 
     /**


### PR DESCRIPTION
MouseEvent.clientX is rounded, while getBoundingClientRect returns a double. In case the user clicks the very start of the wave an error is thrown as handleEvent returns a negative progress.

### Short description of changes:
Added protection to make sure progress value is between 0 and 1
Video demonstrating the issue: https://www.youtube.com/watch?v=ZxAemPyn7Ow

### Breaking in the external API:
No

### Breaking changes in the internal API:
No

